### PR TITLE
Fixing docs broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Hetu's grammar is close to typescript/kotlin/swift and other modern languages, n
 - Function is declared with 'fun, get, set, construct'.
 - Optional type annotation. Variable declared will infer its type from its initializer expression.
 
-[Syntax referrence](https://github.com/hetu-script/site-www/blob/main/docs/en-US/syntax/index.md)
+[Syntax referrence](https://github.com/hetu-script/docs/blob/main/docs/en-US/syntax/index.md)
 
 In your Dart code, you can interpret a script file:
 
@@ -65,7 +65,7 @@ fun main {
 
 Hetu script is purely written in Dart, so passing object to and from script is extremely easy.
 
-Check [this page](https://github.com/hetu-script/site-www/blob/main/docs/en-US/binding/index.md) for more information about how to bind external classes, functions, enums and how to passing object and functions between Dart and script.
+Check [this page](https://github.com/hetu-script/docs/blob/main/docs/en-US/binding/index.md) for more information about how to bind external classes, functions, enums and how to passing object and functions between Dart and script.
 
 ```dart
 import 'package:hetu_script/hetu_script.dart';
@@ -123,8 +123,8 @@ function hello() -> any // repl print
 
 ## Referrences:
 
-- [Operator precedence](https://github.com/hetu-script/site-www/blob/main/docs/en-US/operator_precedence/index.md)
-- [Bytecode specification](https://github.com/hetu-script/site-www/blob/main/docs/en-US/bytecode_specification/index.md)
+- [Operator precedence](https://github.com/hetu-script/docs/blob/main/docs/en-US/operator_precedence/index.md)
+- [Bytecode specification](https://github.com/hetu-script/docs/blob/main/docs/en-US/bytecode_specification/index.md)
 
 ## Apps that embedded Hetu:
 


### PR DESCRIPTION
I have noticed that the links pointing to the docs on the project README are broken, this PR fix them.

PS: I have also noticed that the discord invite is invalid but I am unsure what would be a correct one.

Thanks for this awesome project!