### PR TITLE
Modify the naming convention to support starting with '$'.

### DIFF
--- a/lib/grammar/lexicon.dart
+++ b/lib/grammar/lexicon.dart
@@ -2,7 +2,7 @@
 abstract class HTLexicon {
   static const tokenPattern =
       r'((//.*)|(/\*[\s\S]*\*/))|' // comment group(2 & 3)
-      r'(([_]?[\p{L}]+[\p{L}_0-9]*)|([_]+))|' // unicode identifier group(4)
+      r'(([_\$\p{L}]+[_\$\p{L}0-9]*)|([_]+))|' // unicode identifier group(4)
       r'(\.\.\.|\|\||&&|\+\+|--|\*=|/=|\+=|-=|==|!=|<=|>=|->|=>|[></=%\+\*\-\?!,:;{}\[\]\)\(\.])|' // punctuation group(5)
       r'(0x[0-9a-fA-F]+|\d+(\.\d+)?)|' // number group(6)
       r"('(\\'|[^'])*(\$\{[^\$\{\}]*\})+(\\'|[^'])*')|" // interpolation string with single quotation mark group(8)


### PR DESCRIPTION
支持可以“$”开头的命名规则，使其与其他语言规则类似(TypeScript, Dart)。