### PR TITLE
fix: correct spelling occured->occurred in error message

### DIFF
--- a/examples/error.dart
+++ b/examples/error.dart
@@ -1,7 +1,7 @@
 import 'package:hetu_script/hetu_script.dart';
 
 void ext({positionalArgs, namedArgs}) {
-  throw 'an error occured';
+  throw 'an error occurred';
 }
 
 void main() {


### PR DESCRIPTION
Fixes typo in examples/error.dart

`throw 'an error occured'` → `throw 'an error occurred'`

User-facing error message.