### PR TITLE
fix: correct 'occured' to 'occurred' typo in error.dart example

### DIFF
--- a/examples/error.dart
+++ b/examples/error.dart
@@ -1,7 +1,7 @@
 import 'package:hetu_script/hetu_script.dart';
 
 void ext({positionalArgs, namedArgs}) {
-  throw 'an error occured';
+  throw 'an error occurred';
 }
 
 void main() {


### PR DESCRIPTION
## Summary
Fixes a typo in the error message thrown by the error.dart example.

**File:** examples/error.dart:4
**Before:** `throw 'an error occured';`
**After:** `throw 'an error occurred';`

## Testing
- Verified locally: 1 line changed, 1 insertion, 1 deletion